### PR TITLE
Resolve RawMessage as byte slice with optional reference

### DIFF
--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -7,6 +7,10 @@
       "type": "string",
       "contentEncoding": "base64"
     },
+    "RawMessage": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
     "GrandfatherType": {
       "properties": {
         "family_name": {
@@ -203,7 +207,9 @@
           "type": "array"
         },
         "anything": true,
-        "raw": true
+        "raw": {
+          "$ref": "#/$defs/RawMessage"
+        }
       },
       "type": "object",
       "required": [

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -6,6 +6,10 @@
       "type": "string",
       "contentEncoding": "base64"
     },
+    "RawMessage": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
     "GrandfatherType": {
       "properties": {
         "family_name": {
@@ -203,7 +207,9 @@
       "type": "array"
     },
     "anything": true,
-    "raw": true
+    "raw": {
+      "$ref": "#/$defs/RawMessage"
+    }
   },
   "additionalProperties": false,
   "type": "object",

--- a/fixtures/ignore_type.json
+++ b/fixtures/ignore_type.json
@@ -7,6 +7,10 @@
       "type": "string",
       "contentEncoding": "base64"
     },
+    "RawMessage": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
     "GrandfatherType": {
       "properties": {},
       "additionalProperties": false,
@@ -197,7 +201,9 @@
           "type": "array"
         },
         "anything": true,
-        "raw": true
+        "raw": {
+          "$ref": "#/$defs/RawMessage"
+        }
       },
       "additionalProperties": false,
       "type": "object",

--- a/fixtures/no_reference.json
+++ b/fixtures/no_reference.json
@@ -192,7 +192,10 @@
       "type": "array"
     },
     "anything": true,
-    "raw": true
+    "raw": {
+      "type": "string",
+      "contentEncoding": "base64"
+    }
   },
   "additionalProperties": false,
   "type": "object",

--- a/fixtures/no_reference_anchor.json
+++ b/fixtures/no_reference_anchor.json
@@ -194,7 +194,10 @@
       "type": "array"
     },
     "anything": true,
-    "raw": true
+    "raw": {
+      "type": "string",
+      "contentEncoding": "base64"
+    }
   },
   "additionalProperties": false,
   "type": "object",

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -7,6 +7,10 @@
       "type": "string",
       "contentEncoding": "base64"
     },
+    "RawMessage": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
     "GrandfatherType": {
       "properties": {
         "family_name": {
@@ -204,7 +208,9 @@
           "type": "array"
         },
         "anything": true,
-        "raw": true
+        "raw": {
+          "$ref": "#/$defs/RawMessage"
+        }
       },
       "additionalProperties": false,
       "type": "object",

--- a/fixtures/test_user.json
+++ b/fixtures/test_user.json
@@ -7,6 +7,10 @@
       "type": "string",
       "contentEncoding": "base64"
     },
+    "RawMessage": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
     "GrandfatherType": {
       "properties": {
         "family_name": {
@@ -204,7 +208,9 @@
           "type": "array"
         },
         "anything": true,
-        "raw": true
+        "raw": {
+          "$ref": "#/$defs/RawMessage"
+        }
       },
       "additionalProperties": false,
       "type": "object",

--- a/fixtures/test_user_assign_anchor.json
+++ b/fixtures/test_user_assign_anchor.json
@@ -7,6 +7,10 @@
       "type": "string",
       "contentEncoding": "base64"
     },
+    "RawMessage": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
     "GrandfatherType": {
       "$anchor": "GrandfatherType",
       "properties": {
@@ -206,7 +210,9 @@
           "type": "array"
         },
         "anything": true,
-        "raw": true
+        "raw": {
+          "$ref": "#/$defs/RawMessage"
+        }
       },
       "additionalProperties": false,
       "type": "object",

--- a/reflect.go
+++ b/reflect.go
@@ -288,9 +288,6 @@ var (
 // Byte slices will be encoded as base64
 var byteSliceType = reflect.TypeOf([]byte(nil))
 
-// Except for json.RawMessage
-var rawMessageType = reflect.TypeOf(json.RawMessage{})
-
 // Go code generated from protobuf enum types should fulfil this interface.
 type protoEnum interface {
 	EnumDescriptor() ([]byte, []int)

--- a/reflect.go
+++ b/reflect.go
@@ -445,9 +445,6 @@ func (r *Reflector) reflectSchemaExtend(definitions Definitions, t reflect.Type,
 }
 
 func (r *Reflector) reflectSliceOrArray(definitions Definitions, t reflect.Type, st *Schema) {
-	// if t == rawMessageType {
-	// 	return
-	// }
 
 	r.addDefinition(definitions, t, st)
 

--- a/reflect.go
+++ b/reflect.go
@@ -445,9 +445,9 @@ func (r *Reflector) reflectSchemaExtend(definitions Definitions, t reflect.Type,
 }
 
 func (r *Reflector) reflectSliceOrArray(definitions Definitions, t reflect.Type, st *Schema) {
-	if t == rawMessageType {
-		return
-	}
+	// if t == rawMessageType {
+	// 	return
+	// }
 
 	r.addDefinition(definitions, t, st)
 


### PR DESCRIPTION
json.RawMessage resolves as byte slice, and also can be defined as it's own type "RawMessage" in the json when references are allowed. 